### PR TITLE
Removed un-needed dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The icon build scripts have been moved from the metal-icons package to the parent package.json.
+- The `@babel/runtime` dependency has been removed from the metal-icons package.
 
 ## [0.1.24] - 2023-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2023-03-22
+
+### Changed
+
+- The icon build scripts have been moved from the metal-icons package to the parent package.json.
+
 ## [0.1.24] - 2023-03-21
 
 ### Added

--- a/packages/metal-icons/package.json
+++ b/packages/metal-icons/package.json
@@ -3,17 +3,22 @@
   "private": false,
   "version": "0.1.25",
   "description": "A flexible React icon library.",
+  "homepage": "https://metalicons.com",
   "keywords": [
     "icon-library",
     "icons",
     "react",
     "svg"
   ],
+  "license": "MIT",
+  "author": "Jason Melgoza",
   "repository": {
     "type": "git",
     "url": "https://github.com/jasonmelgoza/metal-icons.git"
   },
-  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jasonmelgoza/metal-icons/issues"
+  },
   "files": [
     "dist"
   ],
@@ -47,7 +52,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^4.1.4"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.23.2"
+  "peerDependencies": {
+    "react": ">= 16"
   }
 }

--- a/packages/metal-icons/package.json
+++ b/packages/metal-icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metal-icons",
   "private": false,
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A flexible React icon library.",
   "keywords": [
     "icon-library",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,7 +12,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-tabs": "^1.0.4",
     "@vercel/og": "^0.5.20",
-    "metal-icons": "*",
+    "metal-icons": "^0.1.25",
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,7 +12,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-tabs": "^1.0.4",
     "@vercel/og": "^0.5.20",
-    "metal-icons": "^0.1.24",
+    "metal-icons": "*",
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/website/src/components/Layout/Layout.js
+++ b/packages/website/src/components/Layout/Layout.js
@@ -90,7 +90,7 @@ export default function Layout({ children }) {
                 href="https://github.com/jasonmelgoza/metal-icons"
                 target="_blank"
               >
-                metal-icons v0.1.24
+                metal-icons v0.1.25
               </a>
             </p>
           </div>

--- a/packages/website/src/pages/api/static.jsx
+++ b/packages/website/src/pages/api/static.jsx
@@ -131,7 +131,7 @@ export default async function handler() {
               color: 'white',
             }}
           >
-            v0.1.5
+            v0.1.25
           </div>
         </div>
         <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -965,7 +965,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.13.10", "@babel/runtime@^7.23.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.8.4":
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.1.tgz#431f9a794d173b53720e69a6464abc6f0e2a5c57"
   integrity sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,7 @@ streamsearch@^1.1.0:
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2624,6 +2625,7 @@ string.prototype.codepointat@^0.2.1:
   integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
# Changed

- The `@babel/runtime` dependency has been removed from the metal-icons package.
- Version bump