### PR TITLE
Update Node.js version in GitHub Actions workflow from 18 to 20.x

### DIFF
--- a/.github/workflows/publish-icons.yml
+++ b/.github/workflows/publish-icons.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
           
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in the GitHub Actions workflow for publishing icons.

* [`.github/workflows/publish-icons.yml`](diffhunk://#diff-eb11c0ffe9588d888ff6ea534a18eae2d2272c9bda5a801c9a0a2ccb84b63e44L31-R31): Updated the Node.js version from `18` to `20.x` in the `Setup Node.js` step to ensure compatibility with the latest features and improvements.