### PR TITLE
Bump metal-icons and website version to 0.2.9

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "website",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "metal-icons": "^0.2.8",
+    "metal-icons": "^0.2.9",
     "motion": "^12.10.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/website/src/data/version.json
+++ b/packages/website/src/data/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.8"
+  "version": "v0.2.9"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,9 +1567,6 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-"metal-icons@file:packages/metal-icons":
-  version "0.2.8"
-
 micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"


### PR DESCRIPTION
This pull request includes a version bump for the `website` package and its dependency `metal-icons` to align with the latest updates.

Version updates:

* Updated the `website` package version from `0.2.8` to `0.2.9` in `packages/website/package.json`.
* Updated the `metal-icons` dependency version from `^0.2.8` to `^0.2.9` in `packages/website/package.json`.
* Updated the version information from `v0.2.8` to `v0.2.9` in `packages/website/src/data/version.json`.