### PR TITLE
Refactor Changelog Workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -54,10 +54,18 @@ jobs:
           # Clean up temp files
           rm TEMP_CHANGELOG.md NEW_ENTRY.md
 
-      - name: Commit and push changes
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add CHANGELOG.md
-          git commit -m "Update changelog for ${{ github.event.release.tag_name || github.event.inputs.version }}" || exit 0
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update changelog for ${{ github.event.release.tag_name || github.event.inputs.version }}"
+          title: "Update changelog for ${{ github.event.release.tag_name || github.event.inputs.version }}"
+          body: |
+            This PR updates the changelog for version ${{ github.event.release.tag_name || github.event.inputs.version }}.
+            
+            Changes are automatically generated based on merged PRs since the last release.
+          branch: update-changelog-${{ github.event.release.tag_name || github.event.inputs.version }}
+          base: main
+          labels: |
+            documentation
+            automated pr


### PR DESCRIPTION
This pull request updates the changelog automation process in the GitHub Actions workflow. Instead of directly committing and pushing changes to the `CHANGELOG.md` file, it now creates a pull request for better visibility and reviewability.

### Workflow automation changes:

* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85L57-R71): Replaced the step that committed and pushed changes with a step that uses the `peter-evans/create-pull-request` action to create a pull request. This includes setting the commit message, PR title, body, branch name, base branch, and labels.