### PR TITLE
Bump package versions to 0.2.10 in root and website

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.10",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "website",
   "private": true,
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request includes version updates for the project and the `website` package to align with the latest release.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the project version from `0.2.8` to `0.2.10`.
* [`packages/website/package.json`](diffhunk://#diff-a5402478b20c22b3a98532d6a9f7a00ddf3bd844951b7adeef37c0473f37c582L4-R4): Updated the `website` package version from `0.2.9` to `0.2.10`.…s for consistency across the project.